### PR TITLE
cmd/alcless: propagate flags to `alclessctl shell`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ To run a command, without rsyncing the current directory:
 ```
 alclessctl shell --plain default bash
 ```
+or
+```
+alcless --plain bash
+```
 
 To remove the sandbox:
 ```

--- a/cmd/alcless
+++ b/cmd/alcless
@@ -10,6 +10,7 @@ BINDIR="$(dirname "$(realpath "$0")")"
 
 : "${ALCLESS_INSTANCE:=default}"
 : "${ALCLESSCTL:="${BINDIR}"/alclessctl}"
+ARGS=()
 
 if [ "$#" -ge 1 ]; then
 	case "$1" in
@@ -27,9 +28,14 @@ if [ "$#" -ge 1 ]; then
 		exec "${ALCLESSCTL}" "$@"
 		;;
 	-*)
-		# TODO: support passing these flags automatically
-		echo >&2 "ERROR: Did you mean: ${ALCLESSCTL} shell $1 ${ALCLESS_INSTANCE} ..."
-		exit 1
+		for f in "$@"; do
+			case "$f" in
+			-*)
+				shift
+				ARGS+=("$f")
+				;;
+			esac
+		done
 		;;
 	"create" | "delete" | "list" | "shell")
 		echo >&2 "WARNING: Perhaps you meant: ${ALCLESSCTL} $1 ..."
@@ -37,5 +43,6 @@ if [ "$#" -ge 1 ]; then
 	esac
 fi
 
-set - "${ALCLESS_INSTANCE}" "$@"
-exec "${ALCLESSCTL}" shell "$@"
+ARGS+=("${ALCLESS_INSTANCE}")
+ARGS+=("$@")
+exec "${ALCLESSCTL}" shell "${ARGS[@]}"


### PR DESCRIPTION
`alclessctl shell --plain default` can be now shortened as `alcless --plain`